### PR TITLE
Fix for deserialization bug in markov chain example

### DIFF
--- a/markov_chain/__init__.py
+++ b/markov_chain/__init__.py
@@ -10,7 +10,6 @@ from six.moves import cPickle
 import numpy
 import theano
 from theano import tensor
-from theano.misc.pkl_utils import load
 
 from blocks.bricks import Tanh
 from blocks.bricks.recurrent import GatedRecurrent

--- a/markov_chain/__init__.py
+++ b/markov_chain/__init__.py
@@ -10,6 +10,7 @@ from six.moves import cPickle
 import numpy
 import theano
 from theano import tensor
+from theano.misc.pkl_utils import load
 
 from blocks.bricks import Tanh
 from blocks.bricks.recurrent import GatedRecurrent
@@ -25,6 +26,7 @@ from blocks.monitoring import aggregation
 from blocks.extensions import FinishAfter, Printing
 from blocks.extensions.saveload import Checkpoint
 from blocks.extensions.monitoring import TrainingDataMonitoring
+from blocks.serialization import load
 from blocks.main_loop import MainLoop
 from blocks.select import Selector
 
@@ -98,8 +100,8 @@ def main(mode, save_path, steps, num_batches):
                         Printing(every_n_batches=100)])
         main_loop.run()
     elif mode == "sample":
-        main_loop = cPickle.load(open(save_path, "rb"))
-        generator = main_loop.model
+        main_loop = load(open(save_path, "rb"))
+        generator = main_loop.model.get_top_bricks()[-1]
 
         sample = ComputationGraph(generator.generate(
             n_steps=steps, batch_size=1, iterate=True)).get_theano_function()


### PR DESCRIPTION
In the markov_chain example, deserialization with cPickle for model sampling caused a persistent id error. Replaced with `blocks.serialization.load` function, along with the appropriate changes to extract the `SequenceGenerator` from the deserialized loop.