### PR TITLE
Fix urls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ before_install:
 install:
   # Install all Python dependencies
   - curl -O https://raw.githubusercontent.com/mila-udem/blocks/master/req-travis-conda.txt
-  - conda install -q --yes python=$TRAVIS_PYTHON_VERSION mkl --file req-travis-conda.txt
+  - conda install -q --yes python=$TRAVIS_PYTHON_VERSION --file req-travis-conda.txt
   - pip install -q -r https://raw.githubusercontent.com/bartvm/blocks/master/req-travis-pip.txt
   - pip install -q git+git://github.com/mila-udem/blocks.git -r https://raw.githubusercontent.com/mila-udem/blocks/master/requirements.txt
   - pip install -q git+git://github.com/mila-udem/blocks-extras.git 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,14 +22,14 @@ before_install:
   - export FUEL_DATA_PATH=$TRAVIS_BUILD_DIR/data
 install:
   # Install all Python dependencies
-  - curl -O https://raw.githubusercontent.com/bartvm/blocks/master/req-travis-conda.txt
+  - curl -O https://raw.githubusercontent.com/mila-udem/blocks/master/req-travis-conda.txt
   - conda install -q --yes python=$TRAVIS_PYTHON_VERSION mkl --file req-travis-conda.txt
   - pip install -q -r https://raw.githubusercontent.com/bartvm/blocks/master/req-travis-pip.txt
-  - pip install -q git+git://github.com/bartvm/blocks.git -r https://raw.githubusercontent.com/bartvm/blocks/master/requirements.txt
+  - pip install -q git+git://github.com/mila-udem/blocks.git -r https://raw.githubusercontent.com/mila-udem/blocks/master/requirements.txt
   - pip install -q git+git://github.com/mila-udem/blocks-extras.git 
   - conda install -q --yes bokeh==0.9.0
   - conda install -q --yes pandas
-  - curl https://raw.githubusercontent.com/bartvm/fuel/download_travis/.travis-data.sh | bash -s -- mnist
+  - curl https://raw.githubusercontent.com/mila-udem/fuel/master/.travis-data.sh | bash -s -- mnist
 script:
   - export THEANO_FLAGS=floatX=$FLOATX,optimizer=fast_compile
   - export FUEL_FLOATX=$FLOATX


### PR DESCRIPTION
Apparently Github changed the form of githubusercontent urls, and the old ones did not work (see failed builds  in #43).