### PR TITLE
Fix docstring of GRUInitialState

### DIFF
--- a/machine_translation/model.py
+++ b/machine_translation/model.py
@@ -112,7 +112,7 @@ class GRUInitialState(GatedRecurrent):
     """Gated Recurrent with special initial state.
 
     Initial state of Gated Recurrent is set by an MLP that conditions on the
-    last hidden state of the bidirectional encoder, applies an affine
+    first hidden state of the bidirectional encoder, applies an affine
     transformation followed by a tanh non-linearity to set initial state.
 
     """


### PR DESCRIPTION
attended[0, :, -self.attended_dim:] corresponds to the first hidden state of the encoder (not the last one)